### PR TITLE
Make it easy to set target Fennec package name.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'com.android.application'
 
+// From gradle.properties.  Override by setting in ~/.gradle/gradle.properties.
+def targetPackageName = property("org.mozilla.gecko.loginsmanager.targetPackageName")
+
 android {
     compileSdkVersion 23
     buildToolsVersion "23.0.2"
@@ -10,7 +13,15 @@ android {
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"
+
+        // targetPackageName is set in gradle.properties.
+        buildConfigField 'String', 'TARGET_PACKAGE_NAME', "\"${targetPackageName}\""
+
+        manifestPlaceholders = [
+            TARGET_PACKAGE_NAME: targetPackageName,
+        ]
     }
+
     buildTypes {
         release {
             minifyEnabled false

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.mozilla.gecko.loginsmanager"
-          android:sharedUserId="org.mozilla.fennec.sharedID">
+          android:sharedUserId="${TARGET_PACKAGE_NAME}.sharedID">
 
     <application android:allowBackup="true"
                  android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/org/mozilla/gecko/loginsmanager/LoginsContract.java
+++ b/app/src/main/java/org/mozilla/gecko/loginsmanager/LoginsContract.java
@@ -9,7 +9,7 @@ import android.net.Uri;
 
 // Contract class for Logins Content Provider.
 public class LoginsContract {
-    private static final Uri LOGINS_AUTHORITY_URI = Uri.parse("content://org.mozilla.fennec.db.logins");
+    private static final Uri LOGINS_AUTHORITY_URI = Uri.parse("content://" + BuildConfig.TARGET_PACKAGE_NAME + ".db.logins");
     public static final Uri LOGINS_URI = Uri.withAppendedPath(LOGINS_AUTHORITY_URI, "logins");
     public static final String HOSTNAME = "hostname";
     public static final String HTTP_REALM = "httpRealm";

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+org.mozilla.gecko.loginsmanager.targetPackageName=org.mozilla.fennec


### PR DESCRIPTION
The target package name is set in gradle.properties.  Override it by
setting the value in ~/.gradle/gradle.properties.

The long name is unusual (for Gradle), but prevents conflicts between
Gradle projects.  See
https://discuss.gradle.org/t/dotted-properties-in-gradle/6845.
